### PR TITLE
[fix] don't stop running when hitting a slack error

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -84,9 +84,8 @@ func Run(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		err = notifier.Send(v, mode == "non-interactive")
-		if err != nil {
-			return err
-		}
+		// TODO report this to sentry
+		log.Error(err)
 	}
 	return nil
 }


### PR DESCRIPTION
Currently if we encounter and error from slack (like the user not
existing) we stop. That's probably fine in interactive mode, but not in
an unsupervised mode.

We should definitely send these errors to sentry, but that is left as a
TODO for now.