### PR TITLE
Upgrade chamber, ensure no reliance on pre-module Go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1 as builder
 
-WORKDIR /go/src/github.com/chanzuckerberg/reaper/
+WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o reaper .
 
 # Install chamber
-ENV CHAMBER_VERSION=v2.1.0
+ENV CHAMBER_VERSION=v2.8.2
 RUN wget -q https://github.com//segmentio/chamber/releases/download/${CHAMBER_VERSION}/chamber-${CHAMBER_VERSION}-linux-amd64 -O /bin/chamber
 RUN chmod +x /bin/chamber
 
@@ -15,7 +15,7 @@ FROM alpine:latest
 RUN apk update && apk --no-cache add ca-certificates
 WORKDIR /root/
 
-COPY --from=0 /go/src/github.com/chanzuckerberg/reaper/reaper /bin/reaper
-COPY --from=0 /bin/chamber /bin/chamber
+COPY --from=builder /app/reaper /bin/reaper
+COPY --from=builder /bin/chamber /bin/chamber
 
-CMD ["./reaper"]
+CMD ["reaper"]


### PR DESCRIPTION
Upgrades chamber to a version compatible with IRSA. Also moves the build directory to force Go not to assume backwards compatibility with GOPATH. Changes the reference for the 2nd stage Docker build to refer to 1st stage by name rather than index. Reaper is not in the in the workdir, so removing the reference to current directory in the CMD.