### PR TITLE
fix: replace reviewdog secret with auto-generated github token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: make ${{ matrix.target }}
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_GITHUB_API_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make ${{ matrix.target }}
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github creates a token specific to every workflow run that grants access to the running repo. https://docs.github.com/en/actions/security-guides/automatic-token-authentication